### PR TITLE
okd/destroy: enable no_log to avoid displaying Account ID

### DIFF
--- a/roles/okd_cluster_destroy/tasks/aws-vpc-endpoint.yaml
+++ b/roles/okd_cluster_destroy/tasks/aws-vpc-endpoint.yaml
@@ -1,12 +1,11 @@
 ---
-- name: Destroy | VPC | AWSe
+- name: Destroy | AWS | VPC Endpoints
   ansible.builtin.debug:
     msg: "Destroy VPC Endpoint service triggered"
   tags: vpc
 
-- name: Get all endpoints with specific filters
+- name: Destroy | AWS | VPCe - get all with filters
   amazon.aws.ec2_vpc_endpoint_info:
-    query: endpoints
     region: "{{ vpc_region }}"
     filters:
       vpc-id:
@@ -16,9 +15,10 @@
         - pending
   register: res_vpce
 
-- name: Delete newly created vpc endpoint
+- name: Destroy | AWS | VPCe - delete endpoints
   amazon.aws.ec2_vpc_endpoint:
     state: absent
     vpc_endpoint_id: "{{ item.vpc_endpoint_id }}"
     region: "{{ vpc_region }}"
   with_items: "{{ res_vpce.vpc_endpoints }}"
+  no_log: True

--- a/roles/okd_cluster_destroy/tasks/aws-vpc-igw.yaml
+++ b/roles/okd_cluster_destroy/tasks/aws-vpc-igw.yaml
@@ -1,13 +1,14 @@
 ---
-- name: Destroy | VPC | AWS
+- name: Destroy | AWS | VPC Internet Gateway
   ansible.builtin.debug:
     msg: "Destroy VPC IGW triggered"
   tags: vpc
 
-- name: "Delete internet gateway"
+- name: Destroy | AWS | VPC IGW - delete internet gateway
   amazon.aws.ec2_vpc_igw:
     region: "{{ vpc_region }}"
     vpc_id: "{{ vpc_id }}"
     state: "absent"
   with_items: "{{ vpc_info.vpcs }}"
   tags: vpc
+  no_log: True

--- a/roles/okd_cluster_destroy/tasks/aws-vpc-rtb.yaml
+++ b/roles/okd_cluster_destroy/tasks/aws-vpc-rtb.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Destroy | VPC | AWS
+- name: Destroy | AWS | VPC Route Tables
   ansible.builtin.debug:
     msg: "Destroy VPC RTB triggered"
   tags: vpc
 
-- name: "Query for existing route table(s)"
+- name: Destroy | AWS | VPC Rtb - qeury existing
   amazon.aws.ec2_vpc_route_table_info:
     region: "{{ vpc_region }}"
     filters:
@@ -12,14 +12,15 @@
   register: route_table_info
   tags: vpc
 
-- name: Destroy | VPC | Rtb | Set tables to delete
+- name: Destroy | AWS | VPC Rtb - set tables to delete
   ansible.builtin.set_fact:
     route_tables_to_delete: "{{ (route_tables_to_delete | default([])) + [item.id] }}"
   when: item.associations | length == 0 or not item.associations[0].main
   loop: "{{ route_table_info.route_tables }}"
   tags: vpc
+  no_log: True
 
-- name: Purge routes
+- name: Destroy | AWS | VPC Rtb - purge routes
   amazon.aws.ec2_vpc_route_table:
     region: "{{ vpc_region }}"
     vpc_id: "{{ vpc_id }}"
@@ -32,12 +33,12 @@
   when: route_tables_to_delete is defined
   tags: vpc
 
-- name: Destroy | VPC | Waiting 10s to propagate
+- name: Destroy | AWS | VPC Rtb - Waiting 10s to propagate
   ansible.builtin.pause:
     seconds: 10
   tags: vpc
 
-- name: "Delete route table"
+- name: Destroy | AWS | VPC Rtb - delete route table
   amazon.aws.ec2_vpc_route_table:
     region: "{{ vpc_region }}"
     vpc_id: "{{ vpc_id }}"

--- a/roles/okd_cluster_destroy/tasks/aws-vpc-sgs.yaml
+++ b/roles/okd_cluster_destroy/tasks/aws-vpc-sgs.yaml
@@ -32,6 +32,7 @@
   when: item.group_name != 'default'
   register: returned_sgs
   tags: vpc
+  no_log: true
 
 - name: AWS | SG - delete
   amazon.aws.ec2_group:
@@ -43,3 +44,4 @@
   register: returned_sgs
   when: item.group_name != 'default'
   tags: vpc
+  no_log: true

--- a/roles/okd_cluster_destroy/tasks/aws-vpc-subnets.yaml
+++ b/roles/okd_cluster_destroy/tasks/aws-vpc-subnets.yaml
@@ -1,24 +1,24 @@
 ---
-- name: Destroy | VPC | AWS
+- name: Destroy | AWS | VPC Subnets
   ansible.builtin.debug:
     msg: "Destroy VPC subnets triggered"
   tags: vpc
   when: debug|d(false)
 
-- name: Get subnets in the VPC
+- name: Destroy | AWS | VPC Subnets - get all subnets
   amazon.aws.ec2_vpc_subnet_info:
     filters:
       vpc-id: "{{ vpc_id }}"
   register: ret_subnets
   tags: vpc
 
-- name: Destroy | VPC | Subnets | Show results
+- name: Destroy | AWS | VPC Subnets - show results
   ansible.builtin.debug:
     var: ret_subnets
   tags: vpc
   when: debug|d(false)
 
-- name: Destroy | AWS | Delete subnets
+- name: Destroy | AWS | VPC Subnets - delete subnets
   amazon.aws.ec2_vpc_subnet:
     state: absent
     region: "{{ vpc_region }}"
@@ -27,3 +27,4 @@
     wait: true
   with_items: "{{ ret_subnets.subnets }}"
   tags: vpc
+  no_log: True


### PR DESCRIPTION
- Enable `no_log` for tasks which  is logging the AWS AccountID when `changed`. It is useful to avoid leak this information publically when using this Collection in public environments, like CI
- Review naming conventions on the changed files