### PR TITLE
feat/ci: pin amazon.aws to the distributed by ansible

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -5,10 +5,12 @@
 # of the distributed on the ansible minor version(y).
 
 collections:
+- name: community.kubernetes
+  version: '>=2.0.0,<3.0.0'
 
 # The version 5x was crashing when using ansible==6.4.0, setting to the major
 # distributed on that ansible version: 3.y.z
 - name: community.aws
   version: '>=3.0.0,<4.0.0'
-- name: community.kubernetes
-  version: '>=2.0.0,<3.0.0'
+- name: amazon.aws
+  version: '>=3.0.0,<4.0.0'


### PR DESCRIPTION
Complementing https://github.com/mtulio/ansible-collection-okd-installer/pull/16 to fix Collection `amazon.aws` to the same distributed by Ansible

```
$ podman run --rm quay.io/mrbraga/okd-installer:0.0.0-ci.165-3809092794 ansible --version
ansible [core 2.13.7]
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.9/site-packages/ansible
  ansible collection location = /root/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/local/bin/ansible
  python version = 3.9.16 (main, Dec  8 2022, 00:00:00) [GCC 11.3.1 20221121 (Red Hat 11.3.1-4)]
  jinja version = 3.1.2
  libyaml = True

# Version built by #16 (5.1.0 )
$ podman run --rm quay.io/mrbraga/okd-installer:0.0.0-ci.165-3809092794 ansible-galaxy collection list |grep aws
amazon.aws                    3.4.0  
community.aws                 3.5.0  
netapp.aws                    21.7.0 
amazon.aws           5.1.0                  
community.aws        3.6.0                  

# /root/.ansible/collections/ansible_collections
Collection           Version                
-------------------- -----------------------
amazon.aws           5.1.0                  
community.aws        3.6.0                  
community.kubernetes 2.0.1                  
kubernetes.core      2.3.2                  
mtulio.okd_installer 0.0.0-ci.165-3809092794

# Latest release :0.1.0-beta6

$ podman run --rm quay.io/mrbraga/okd-installer:0.1.0-beta6 ansible-galaxy collection list |grep aws
amazon.aws           5.1.0      
community.aws        5.1.0      
amazon.aws                    3.4.0  
community.aws                 3.5.0  
netapp.aws                    21.7.0 

# /root/.ansible/collections/ansible_collections
Collection           Version    
-------------------- -----------
amazon.aws           5.1.0      
community.aws        5.1.0      
community.kubernetes 2.0.1      
kubernetes.core      2.3.2      
mtulio.okd_installer 0.1.0-beta6

```