### PR TITLE
fix/ansible-unsafe: Enable unsafe writes by default

### DIFF
--- a/hack/Containerfile
+++ b/hack/Containerfile
@@ -1,5 +1,7 @@
 FROM quay.io/centos/centos:stream9
 
+ENV ANSIBLE_UNSAFE_WRITES=1
+
 WORKDIR /okd-installer
 
 RUN dnf install python3-pip -y \


### PR DESCRIPTION
Allowing unsafe writes by default **on containerized environments** to avoid errors when installing clients (OCP/OKD) on containers environment.

```
TASK [mtulio.okd_installer.okd_install_clients : Extract the clients from tarball - installer] ***
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: 
PermissionError: [Errno 13] Permission denied: 
b'/root/.ansible/okd-installer/bin/.ansible_tmp49ayf3vgopenshift-install-linux-4.12.0-rc.4'

fatal: [localhost]: FAILED! => {"changed": false, "checksum": "457c6de0148209f830e825c1983de7a67c6e6124", 
"msg": "Failed to replace file: b'/root/.ansible/tmp/ansible-tmp-1672340666.5004282-261-189118508737918/source' 
to /root/.ansible/okd-installer/bin/openshift-install-linux-4.12.0-rc.4: 
[Errno 13] Permission denied: 
b'/root/.ansible/okd-installer/bin/.ansible_tmp49ayf3vgopenshift-install-linux-4.12.0-rc.4'"}
```

From the [module affected](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/unarchive_module.html):

```text
Influence when to use atomic operation to prevent data corruption or inconsistent reads from the target 
filesystem object.

By default this module uses atomic operations to prevent data corruption or inconsistent reads 
from the target filesystem objects, but sometimes systems are configured or just broken in ways 
that prevent this. One example is docker mounted filesystem objects, which cannot be updated
 atomically from inside the container and can only be written in an unsafe manner.

This option allows Ansible to fall back to unsafe methods of updating filesystem objects when 
atomic operations fail (however, it doesn’t force Ansible to perform unsafe writes).

IMPORTANT! Unsafe writes are subject to race conditions and can lead to data corruption.
```

Issue `https://docs.ansible.com/ansible/latest/collections/ansible/builtin/unarchive_module.html`