### PR TITLE
fixes: add retries on tasks failing external APIs (KAS, AWS TG, etc)

### DIFF
--- a/roles/okd_approve_certificates/tasks/approve-check.yaml
+++ b/roles/okd_approve_certificates/tasks/approve-check.yaml
@@ -8,6 +8,9 @@
       - "node-role.kubernetes.io/worker"
     kubeconfig: "{{ config_install_dir }}/auth/kubeconfig"
   register: all_nodes
+  until: "all_nodes is not failed"
+  retries: 5
+  delay: 5
 
 - name: Set worker node counter
   ansible.builtin.set_fact:


### PR DESCRIPTION
Retry on tasks failing for external API instabilities:

- [x] 1) AWS TG API randomly failing:

https://github.com/mtulio/ansible-role-cloud-load-balancer/pull/9

- [x] 2) KAS refusing connections:
```
TASK [mtulio.okd_installer.okd_approve_certificates : Getting existing nodes] ***
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to get client due to 
HTTPSConnectionPool(host='api.opct22123101.devcluster.openshift.com', port=6443): 
Max retries exceeded with url: /version 
(Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7fe8c7dd4520>: 
Failed to establish a new connection: [Errno 111] Connection refused'))"}

PLAY RECAP *********************************************************************
localhost                  : ok=441  changed=39   unreachable=0    failed=1    skipped=164  rescued=0    ignored=0 
```

- [x] Tested full execution